### PR TITLE
Update Java 8 to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.1-jdk-8-slim
+FROM maven:3.6.1-jdk-11-slim
 # create working directory and set
 RUN mkdir /consistency-checker
 ADD . /consistency-checker
@@ -6,6 +6,6 @@ WORKDIR /consistency-checker
 RUN mvn clean install
 
 # copy jar and set entrypoint
-FROM openjdk:8-slim
+FROM openjdk:11-slim
 COPY --from=0 /consistency-checker/target/consistency_checker.jar /consistency-checker/consistency_checker.jar
 ENTRYPOINT ["java"]


### PR DESCRIPTION
Address TLS handshake error: EOF

```
Client connection created
[1] 2022/07/18 18:02:02.197762 [DBG] 172.24.0.6:39244 - cid:48 - Starting TLS client connection handshake
[1] 2022/07/18 18:02:04.073192 [ERR] 172.24.0.6:39244 - cid:48 - TLS handshake error: EOF
[1] 2022/07/18 18:02:04.073316 [DBG] 172.24.0.6:39244 - cid:48 - Client connection closed: TLS Handshake Failure
```

as suggested by 
[https://github.com/nats-io/nats.java/issues/273](https://github.com/nats-io/nats.java/issues/273)
